### PR TITLE
Replace Inter with Bricolage Grotesque font and update typography

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import LightDarkModeToggle from "@/components/LightDarkModeToggle";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
-import { Crimson_Pro, Inter } from "next/font/google";
+import { Bricolage_Grotesque, Crimson_Pro } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import { headline, tagline } from "./page";
@@ -46,10 +46,10 @@ const crimson_pro = Crimson_Pro({
   variable: "--font-crimson-pro",
 });
 
-const inter = Inter({
+const bricolage_grotesque = Bricolage_Grotesque({
   subsets: ["latin"],
   display: "swap",
-  variable: "--font-inter",
+  variable: "--font-bricolage_grotesque",
 });
 
 export default function RootLayout({
@@ -61,7 +61,7 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${crimson_pro.variable} ${inter.variable}`}
+      className={`${crimson_pro.variable} ${bricolage_grotesque.variable}`}
     >
       <Script
         src="https://app.tinyanalytics.io/pixel/DbzDhIpSbsBIoTz9"
@@ -69,7 +69,7 @@ export default function RootLayout({
       />
       <body>
         <ThemeProvider disableTransitionOnChange attribute="data-mode">
-          <div className="relative">
+          <div className="relative font-light font-body">
             <div className="fixed right-0 top-0 z-20">
               <LightDarkModeToggle />
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { experiences } from "@/lib/workExperienceData";
 import Image from "next/image";
 import Link from "next/link";
 
-export const tagline = "CS undergrad, fullstack developer";
+export const tagline = "CS undergrad, software developer";
 export const headline =
   "I build software with purpose and create impactful solutions through user-centric design";
 
@@ -30,23 +30,23 @@ export default function Home() {
           </div>
           <div className="flex flex-col gap-5 md:gap-7">
             <div className="flex flex-col">
-              <h1 className="font-serif text-4xl leading-9 md:text-6xl md:leading-none">
+              <h1 className="font-header text-4xl leading-9 md:text-6xl md:leading-none">
                 Owen Gretzinger
               </h1>
-              <p className="-mb-2 font-serif text-lg md:text-2xl">{tagline}</p>
+              <p className="-mb-2 font-header text-lg md:text-2xl">{tagline}</p>
             </div>
             <p className="max-w-[330px] text-sm text-grey md:max-w-[420px] md:text-lg">
               {headline}
             </p>
             <div className="flex flex-col gap-[10px] md:flex-row">
               <SocialLink link="linkedin" />
-              <SocialLink link="email" />
               <SocialLink link="github" />
+              <SocialLink link="email" />
             </div>
           </div>
         </section>
         <section className="flex w-full flex-col gap-[20px]">
-          <h1 className="font-serif text-4xl">Work Experience</h1>
+          <h1 className="font-header text-4xl">Work Experience</h1>
           <div className="flex flex-col gap-[20px] md:flex-row md:flex-wrap">
             {Object.keys(experiences).map((experience) => (
               <WorkExperienceCard
@@ -62,7 +62,7 @@ export default function Home() {
           />
         </section>
         <section className="flex w-full flex-col gap-[20px]">
-          <h1 className="font-serif text-4xl">Projects</h1>
+          <h1 className="font-header text-4xl">Projects</h1>
           <div className="flex flex-wrap gap-[20px]">
             {Object.keys(projects)
               .slice(0, 5)
@@ -89,7 +89,7 @@ export default function Home() {
           />
         </section>
         <section className="flex w-full flex-col gap-[20px]">
-          <h1 className="font-serif text-4xl">That&apos;s all</h1>
+          <h1 className="font-header text-4xl">That&apos;s all</h1>
           <div className="flex flex-col gap-[10px]">
             <LinkWithUpRightArrow
               text="Add me on LinkedIn"
@@ -107,7 +107,7 @@ export default function Home() {
         <Link
           href="https://github.com/owengretzinger"
           target="_blank"
-          className="font-serif text-lg text-grey transition-colors hover:text-darkTeal focus-visible:text-darkTeal"
+          className="font-header text-lg text-grey transition-colors hover:text-darkTeal focus-visible:text-darkTeal"
         >
           Designed & built by Owen Gretzinger
         </Link>

--- a/src/components/WorkExperienceCard.tsx
+++ b/src/components/WorkExperienceCard.tsx
@@ -27,7 +27,7 @@ export default function WorkExperienceCard({
               className="h-[48px] w-[48px] rounded border border-lightGrey"
               priority
             />
-            <div className="flex flex-col text-black">
+            <div className="mt-1 flex flex-col text-black">
               <span className="font-semibold">{info.title}</span>
               <span>{info.company}</span>
             </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,8 +17,8 @@ module.exports = {
       white: "rgb(var(--color-white) / <alpha-value>)",
     },
     fontFamily: {
-      serif: ["var(--font-crimson-pro)"],
-      sans: ["var(--font-inter)"],
+      header: ["var(--font-crimson-pro)"],
+      body: ["var(--font-bricolage_grotesque)"],
     },
     extend: {},
   },


### PR DESCRIPTION
### TL;DR

Updated font styles, tagline, and layout adjustments for improved visual consistency.

### What changed?

- Replaced Inter font with Bricolage Grotesque for body text
- Updated tagline from "fullstack developer" to "software developer"
- Adjusted font classes throughout the components for consistency
- Reordered social links (GitHub now precedes email)
- Added `font-light` and `font-body` classes to the main layout div
- Adjusted vertical alignment in WorkExperienceCard

### Why make this change?

These changes aim to enhance the visual appeal and consistency of the portfolio website. The new font pairing and adjusted layout provide a more polished look, while the updated tagline more accurately reflects the developer's focus. The reordering of social links prioritizes professional profiles.